### PR TITLE
Update pretrained tts models

### DIFF
--- a/egs/datasets/README.md
+++ b/egs/datasets/README.md
@@ -163,7 +163,7 @@ The official LibriTTS dataset can be download [here](https://www.openslr.org/60/
 
 ## LJSpeech
 
-The official LibriTTS dataset can be download [here](https://keithito.com/LJ-Speech-Dataset/). The file structure tree is like:
+The official LJSpeech dataset can be download [here](https://keithito.com/LJ-Speech-Dataset/). The file structure tree is like:
 
 ```plaintext
 [LJSpeech dataset path]

--- a/egs/tts/README.md
+++ b/egs/tts/README.md
@@ -14,4 +14,4 @@ Until now, Amphion TTS supports the following models or architectures,
 - **[NaturalSpeech2](NaturalSpeech2)** (👨‍💻 developing): An architecture for TTS that utilizes a latent diffusion model to generate natural-sounding voices.
 
 ## Amphion TTS Demo
-Here are some [TTS samples](https://openhlt.github.io/Amphion_TTS_Demo/) from Amphion (👨‍💻 developing).
+Here are some [TTS samples](https://openhlt.github.io/Amphion_TTS_Demo/) from Amphion.

--- a/egs/tts/VALLE/README.md
+++ b/egs/tts/VALLE/README.md
@@ -127,7 +127,7 @@ sh egs/tts/VALLE/run.sh --stage 3 --gpu "0" \
 ```
 
 
-We will release a pre-trained VALL-E. So you can download the pre-trained model and generate speech following the above inference instruction.
+We released a pre-trained Amphion VALL-E model. So you can download the pre-trained model [here](https://huggingface.co/amphion/valle-libritts) and generate speech following the above inference instruction.
 
 ```bibtex
 @article{wang2023neural,

--- a/egs/tts/VITS/README.md
+++ b/egs/tts/VITS/README.md
@@ -121,7 +121,7 @@ sh egs/tts/VITS/run.sh --stage 3 --gpu "0" \
     --infer_text "This is a clip of generated speech with the given text from a TTS model."
 ```
 
-We will release a pre-trained VITS model trained on LJSpeech. So you can download the pre-trained model and generate speech following the above inference instruction.
+We released a pre-trained Amphion VITS model trained on LJSpeech. So you can download the pre-trained model [here](https://huggingface.co/amphion/vits-ljspeech) and generate speech following the above inference instruction.
 
 
 ```bibtex


### PR DESCRIPTION
This PR is to update TTS recipes to add pre-trained TTS models' links. 
Changed files:
* egs/tts/VALLE/README.md
* egs/tts/VITS/README.md

Also, fix a typo in the description part of LJSpeech dataset.
Changed files:
* egs/datasets/README.md

Delete the world of "developing" in TTS demo part.
Changed files:
* egs/tts/README.md
