### PR TITLE
Fix VitsSVC model infer bug when using nsfhifigan as generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ ckpts
 *.pt
 *.npy
 *.npz
-!modules/whisper_extractor/assets/mel_filters.npz
 *.tar.gz
 *.ckpt
 *.wav

--- a/models/svc/vits/vits.py
+++ b/models/svc/vits/vits.py
@@ -263,7 +263,7 @@ class SynthesizerTrn(nn.Module):
         z = self.flow(z_p, c_mask, g=g, reverse=True)
 
         if self.dec_name == "nsfhifigan":
-            o = self.dec(z * c_mask, f0=f0)
+            o = self.dec(z * c_mask, f0=f0.float())
         elif self.dec_name == "apnet":
             _, _, _, _, o = self.dec(z * c_mask)
         else:


### PR DESCRIPTION
As title: This PR is to fix a bug when using NSF-HiFi-GAN as generator