### PR TITLE
Avoid Unbound Case of the download_root

### DIFF
--- a/processors/content_extractor.py
+++ b/processors/content_extractor.py
@@ -198,6 +198,11 @@ class WhisperExtractor(BaseExtractor):
             elif os.path.isdir(self.cfg.preprocess.whisper_model_path):
                 # "pretrained/whisper"
                 download_root = self.cfg.preprocess.whisper_model_path
+            else:
+                # if the path is not exist, download the model to the path
+                download_root = self.cfg.preprocess.whisper_model_path
+                if download_root.endswith(".pt"):
+                    download_root = os.path.dirname(download_root)
         else:
             download_root = None
 

--- a/processors/content_extractor.py
+++ b/processors/content_extractor.py
@@ -199,7 +199,7 @@ class WhisperExtractor(BaseExtractor):
                 # "pretrained/whisper"
                 download_root = self.cfg.preprocess.whisper_model_path
             else:
-                # if the path is not exist, download the model to the path
+                # if the path does not exist, download the model to the path
                 download_root = self.cfg.preprocess.whisper_model_path
                 if download_root.endswith(".pt"):
                     download_root = os.path.dirname(download_root)


### PR DESCRIPTION
I made a mistake that I forgot to handle the unbound case of the whisper's `download_root`.
If the given path does not exist, the program will shut down due to the unbound case.
I've fixed the problem and the demo is good to go.