### PR TITLE
Fix Compatibility Issue with 'accelerate' Package by Reverting to Version 0.24.1

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -9,7 +9,7 @@ conda install -c conda-forge ffmpeg
 # Pip packages
 pip install setuptools ruamel.yaml tqdm colorama easydict tabulate loguru json5 Cython unidecode inflect argparse g2p_en tgt librosa matplotlib typeguard einops omegaconf hydra-core humanfriendly pandas
 
-pip install tensorboard tensorboardX torch==2.0.1 torchaudio==2.0.2 torchvision==0.15.2 transformers diffusers accelerate praat-parselmouth audiomentations pedalboard ffmpeg-python==0.2.0 pyworld diffsptk nnAudio unidecode inflect ptwt
+pip install tensorboard tensorboardX torch==2.0.1 torchaudio==2.0.2 torchvision==0.15.2 accelerate==0.24.1 transformers diffusers praat-parselmouth audiomentations pedalboard ffmpeg-python==0.2.0 pyworld diffsptk nnAudio unidecode inflect ptwt
 
 pip install torchmetrics pymcd openai-whisper frechet_audio_distance asteroid
 


### PR DESCRIPTION
Description of the PR:
This PR addresses an issue related to file extension handling in newer versions of the 'accelerate' package.

Related Issue:
1. https://github.com/open-mmlab/Amphion/issues/67
2. https://github.com/open-mmlab/Amphion/issues/31#issuecomment-1868771600

Cause of the Error:
The issue appears to be linked to a change in file extension processing, introduced in recent updates of the 'accelerate' package. Comparing the codebase of different versions of 'accelerate' indicates that changes were made between versions 0.24.1 and 0.25.0.

Reference:
[accelerate v0.25.0 - accelerator.py](https://github.com/huggingface/accelerate/blob/v0.25.0/src/accelerate/accelerator.py)
[accelerate v0.24.1 - accelerator.py](https://github.com/huggingface/accelerate/blob/v0.24.1/src/accelerate/accelerator.py)

Proposed Solution:
To address this compatibility issue, this PR suggests reverting to version 0.24.1 of the 'accelerate' package. This can be achieved by specifying version 0.24.1 in the env.sh script. 