### PR TITLE
fix calc_metrics.py and word_error_rate.py

### DIFF
--- a/bins/calc_metrics.py
+++ b/bins/calc_metrics.py
@@ -65,8 +65,6 @@ METRIC_FUNC = {
 }
 
 
-# --------wsy fix---------------------------------------------------------------------------------------------
-# def calc_metric(ref_dir, deg_dir, dump_dir, metrics, fs=None):
 def calc_metric(
     ref_dir,
     deg_dir,
@@ -77,7 +75,6 @@ def calc_metric(
     ltr_path=None,
     language="english",
 ):
-    # -------------------------------------------------------------------------------------------------------------
     result = defaultdict()
 
     for metric in tqdm(metrics):
@@ -115,7 +112,6 @@ def calc_metric(
             result[metric] = str(tp_total / (tp_total + (fp_total + fn_total) / 2))
         else:
             scores = []
-            # ------wsy add--------------------------------------------------
             if metric == "wer":
                 import whisper
 
@@ -136,15 +132,10 @@ def calc_metric(
                     ltrs = []
                     for file in files:
                         ltrs.append(tmpltrs[os.path.basename(file)])
-            # ----------------------------------------------------------------
             for i in tqdm(range(len(audios_ref))):
                 audio_ref = audios_ref[i]
                 audio_deg = audios_deg[i]
 
-                # ---wsy fix----------------------------------------------
-                # score = METRIC_FUNC[metric](
-                #     audio_ref=audio_ref, audio_deg=audio_deg, fs=fs
-                # )
                 if metric == "wer":
                     if wer_choose == 1:
                         score = METRIC_FUNC[metric](
@@ -171,7 +162,6 @@ def calc_metric(
                         audio_deg=audio_deg,
                         fs=fs,
                     )
-                # ---------------------------------------------------------
                 if not np.isnan(score):
                     scores.append(score)
 
@@ -190,18 +180,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--ref_dir",
         type=str,
-        # ---------wsy fix------------------------
-        # help="Path to the target audio folder.",
         help="Path to the reference audio folder.",
-        # -----------------------------------------
     )
     parser.add_argument(
         "--deg_dir",
         type=str,
-        # ---------wsy fix---------------------------
-        # help="Path to the reference audio folder.",
         help="Path to the test audio folder.",
-        # --------------------------------------------
     )
     parser.add_argument(
         "--dump_dir",
@@ -218,7 +202,6 @@ if __name__ == "__main__":
         type=str,
         help="(Optional) Sampling rate",
     )
-    # -----------wsy add-------------------------------------------------------------------------
     parser.add_argument(
         "--wer_choose",
         type=int,
@@ -239,12 +222,9 @@ if __name__ == "__main__":
         default="english",
         help="(Optional)['english','chinese']",
     )
-    # --------------------------------------------------------------------------------------------
 
     args = parser.parse_args()
 
-    # -----------wsy fix------------------------------------------------------------
-    # calc_metric(args.ref_dir, args.deg_dir, args.dump_dir, args.metrics, args.fs)
     calc_metric(
         args.ref_dir,
         args.deg_dir,
@@ -255,4 +235,3 @@ if __name__ == "__main__":
         args.ltr_path,
         args.language,
     )
-    # --------------------------------------------------------------------------------

--- a/bins/calc_metrics.py
+++ b/bins/calc_metrics.py
@@ -13,6 +13,7 @@ from glob import glob
 from tqdm import tqdm
 from collections import defaultdict
 
+
 from evaluation.metrics.energy.energy_rmse import extract_energy_rmse
 from evaluation.metrics.energy.energy_pearson_coefficients import (
     extract_energy_pearson_coeffcients,
@@ -64,7 +65,19 @@ METRIC_FUNC = {
 }
 
 
-def calc_metric(ref_dir, deg_dir, dump_dir, metrics, fs=None):
+# --------wsy fix---------------------------------------------------------------------------------------------
+# def calc_metric(ref_dir, deg_dir, dump_dir, metrics, fs=None):
+def calc_metric(
+    ref_dir,
+    deg_dir,
+    dump_dir,
+    metrics,
+    fs=None,
+    wer_choose=1,
+    ltr_path=None,
+    language="english",
+):
+    # -------------------------------------------------------------------------------------------------------------
     result = defaultdict()
 
     for metric in tqdm(metrics):
@@ -102,14 +115,63 @@ def calc_metric(ref_dir, deg_dir, dump_dir, metrics, fs=None):
             result[metric] = str(tp_total / (tp_total + (fp_total + fn_total) / 2))
         else:
             scores = []
+            # ------wsy add--------------------------------------------------
+            if metric == "wer":
+                import whisper
 
+                model = whisper.load_model("large").cuda()
+                if wer_choose == 2:
+                    tmpltrs = {}
+                    with open(ltr_path, "r") as f:
+                        for line in f:
+                            paras = line.replace("\n", "").split("|")
+                            paras[1] = paras[1].replace(" ", "")
+                            paras[1] = paras[1].replace(".", "")
+                            paras[1] = paras[1].replace("'", "")
+                            paras[1] = paras[1].replace("-", "")
+                            paras[1] = paras[1].replace(",", "")
+                            paras[1] = paras[1].replace("!", "")
+                            paras[1] = paras[1].lower()
+                            tmpltrs[paras[0]] = paras[1]
+                    ltrs = []
+                    for file in files:
+                        ltrs.append(tmpltrs[os.path.basename(file)])
+            # ----------------------------------------------------------------
             for i in tqdm(range(len(audios_ref))):
                 audio_ref = audios_ref[i]
                 audio_deg = audios_deg[i]
 
-                score = METRIC_FUNC[metric](
-                    audio_ref=audio_ref, audio_deg=audio_deg, fs=fs
-                )
+                # ---wsy fix----------------------------------------------
+                # score = METRIC_FUNC[metric](
+                #     audio_ref=audio_ref, audio_deg=audio_deg, fs=fs
+                # )
+                if metric == "wer":
+                    if wer_choose == 1:
+                        score = METRIC_FUNC[metric](
+                            audio_ref=audio_ref,
+                            audio_deg=audio_deg,
+                            fs=fs,
+                            model=model,
+                            language=language,
+                        )
+                    elif wer_choose == 2:
+                        content_ref = ltrs[i]
+                        score = METRIC_FUNC[metric](
+                            audio_ref=audio_ref,
+                            audio_deg=audio_deg,
+                            fs=fs,
+                            model=model,
+                            content_gt=content_ref,
+                            mode="gt_content",
+                            language=language,
+                        )
+                else:
+                    score = METRIC_FUNC[metric](
+                        audio_ref=audio_ref,
+                        audio_deg=audio_deg,
+                        fs=fs,
+                    )
+                # ---------------------------------------------------------
                 if not np.isnan(score):
                     scores.append(score)
 
@@ -128,12 +190,18 @@ if __name__ == "__main__":
     parser.add_argument(
         "--ref_dir",
         type=str,
-        help="Path to the target audio folder.",
+        # ---------wsy fix------------------------
+        # help="Path to the target audio folder.",
+        help="Path to the reference audio folder.",
+        # -----------------------------------------
     )
     parser.add_argument(
         "--deg_dir",
         type=str,
-        help="Path to the reference audio folder.",
+        # ---------wsy fix---------------------------
+        # help="Path to the reference audio folder.",
+        help="Path to the test audio folder.",
+        # --------------------------------------------
     )
     parser.add_argument(
         "--dump_dir",
@@ -150,6 +218,41 @@ if __name__ == "__main__":
         type=str,
         help="(Optional) Sampling rate",
     )
+    # -----------wsy add-------------------------------------------------------------------------
+    parser.add_argument(
+        "--wer_choose",
+        type=int,
+        default=1,
+        help="(Optional)The method of calculating WER, where choose set to 1 means selecting \
+        the recognition content of the reference audio as the target, and choose set to 2 means \
+        using transcription as the target",
+    )
+    parser.add_argument(
+        "--ltr_path",
+        type=str,
+        help="(Optional)Path to the transcription file,Note that the format in the transcription \
+            file is 'file name|transcription'",
+    )
+    parser.add_argument(
+        "--language",
+        type=str,
+        default="english",
+        help="(Optional)['english','chinese']",
+    )
+    # --------------------------------------------------------------------------------------------
+
     args = parser.parse_args()
 
-    calc_metric(args.ref_dir, args.deg_dir, args.dump_dir, args.metrics, args.fs)
+    # -----------wsy fix------------------------------------------------------------
+    # calc_metric(args.ref_dir, args.deg_dir, args.dump_dir, args.metrics, args.fs)
+    calc_metric(
+        args.ref_dir,
+        args.deg_dir,
+        args.dump_dir,
+        args.metrics,
+        args.fs,
+        args.wer_choose,
+        args.ltr_path,
+        args.language,
+    )
+    # --------------------------------------------------------------------------------

--- a/evaluation/metrics/intelligibility/word_error_rate.py
+++ b/evaluation/metrics/intelligibility/word_error_rate.py
@@ -17,7 +17,7 @@ def extract_wer(
     remove_space=True,
     remove_punctuation=True,
     mode="gt_audio",
-    model=None,  # wsy add
+    model=None, 
 ):
     """Compute Word Error Rate (WER) between the predicted and the ground truth audio.
     content_gt: the ground truth content.
@@ -33,18 +33,15 @@ def extract_wer(
         assert content_gt != None
         if language == "chinese":
             prompt = "以下是普通话的句子"
-            # model = whisper.load_model("large").cuda() # wsy fix
             result_deg = model.transcribe(
                 audio_deg, language="zh", verbose=True, initial_prompt=prompt
             )
         elif language == "english":
-            # model = whisper.load_model("large").cuda() # wsy fix
             result_deg = model.transcribe(audio_deg, language="en", verbose=True)
     elif mode == "gt_audio":
         assert audio_ref != None
         if language == "chinese":
             prompt = "以下是普通话的句子"
-            # model = whisper.load_model("large").cuda() # wsy fix
             result_ref = model.transcribe(
                 audio_ref, language="zh", verbose=True, initial_prompt=prompt
             )
@@ -52,12 +49,7 @@ def extract_wer(
                 audio_deg, language="zh", verbose=True, initial_prompt=prompt
             )
         elif language == "english":
-            # model = whisper.load_model("large").cuda() # wsy fix
-
-            # --------wsy fix------------------------------------------------------
-            # result_ref = model.transcribe(audio_deg, language="en", verbose=True)
             result_ref = model.transcribe(audio_ref, language="en", verbose=True)
-            # ---------------------------------------------------------------------
             result_deg = model.transcribe(audio_deg, language="en", verbose=True)
         content_gt = result_ref["text"]
         if remove_space:

--- a/evaluation/metrics/intelligibility/word_error_rate.py
+++ b/evaluation/metrics/intelligibility/word_error_rate.py
@@ -17,6 +17,7 @@ def extract_wer(
     remove_space=True,
     remove_punctuation=True,
     mode="gt_audio",
+    model=None,  # wsy add
 ):
     """Compute Word Error Rate (WER) between the predicted and the ground truth audio.
     content_gt: the ground truth content.
@@ -32,18 +33,18 @@ def extract_wer(
         assert content_gt != None
         if language == "chinese":
             prompt = "以下是普通话的句子"
-            model = whisper.load_model("large").cuda()
+            # model = whisper.load_model("large").cuda() # wsy fix
             result_deg = model.transcribe(
                 audio_deg, language="zh", verbose=True, initial_prompt=prompt
             )
         elif language == "english":
-            model = whisper.load_model("large").cuda()
+            # model = whisper.load_model("large").cuda() # wsy fix
             result_deg = model.transcribe(audio_deg, language="en", verbose=True)
     elif mode == "gt_audio":
         assert audio_ref != None
         if language == "chinese":
             prompt = "以下是普通话的句子"
-            model = whisper.load_model("large").cuda()
+            # model = whisper.load_model("large").cuda() # wsy fix
             result_ref = model.transcribe(
                 audio_ref, language="zh", verbose=True, initial_prompt=prompt
             )
@@ -51,8 +52,12 @@ def extract_wer(
                 audio_deg, language="zh", verbose=True, initial_prompt=prompt
             )
         elif language == "english":
-            model = whisper.load_model("large").cuda()
-            result_ref = model.transcribe(audio_deg, language="en", verbose=True)
+            # model = whisper.load_model("large").cuda() # wsy fix
+
+            # --------wsy fix------------------------------------------------------
+            # result_ref = model.transcribe(audio_deg, language="en", verbose=True)
+            result_ref = model.transcribe(audio_ref, language="en", verbose=True)
+            # ---------------------------------------------------------------------
             result_deg = model.transcribe(audio_deg, language="en", verbose=True)
         content_gt = result_ref["text"]
         if remove_space:

--- a/evaluation/metrics/intelligibility/word_error_rate.py
+++ b/evaluation/metrics/intelligibility/word_error_rate.py
@@ -17,7 +17,7 @@ def extract_wer(
     remove_space=True,
     remove_punctuation=True,
     mode="gt_audio",
-    model=None, 
+    model=None,
 ):
     """Compute Word Error Rate (WER) between the predicted and the ground truth audio.
     content_gt: the ground truth content.


### PR DESCRIPTION
## ✨ Description

background: The code for the original evaluation of Word Error Rate (WER) is slow and cannot calculate WER based on transcription as the ground truth."
purpose:  Accelerate the batch evaluation of Word Error Rate (WER) and add code to calculate WER based on transcription as the ground truth.
changes made: change code in calc_metrics.py and word_error_rate.py , and Labeled as 'wsy fix'
how to test this PR: You can perform testing by setting the entry parameters of calc_metrics.py.

