### PR TITLE
Fix bug for VITS resuming training

### DIFF
--- a/egs/tts/VITS/README.md
+++ b/egs/tts/VITS/README.md
@@ -74,13 +74,55 @@ We provide the default hyparameters in the `exp_config.json`. They can work on s
     }
 ```
 
-### Run
+### Train From Scratch
 
 Run the `run.sh` as the training stage (set  `--stage 2`). Specify a experimental name to run the following command. The tensorboard logs and checkpoints will be saved in `Amphion/ckpts/tts/[YourExptName]`.
 
 ```bash
 sh egs/tts/VITS/run.sh --stage 2 --name [YourExptName]
 ```
+
+### Train From Existing Source
+
+We support training from existing source for various purposes. You can resume training the model from a checkpoint or fine-tune a model from another checkpoint.
+
+Setting `--resume true`, the training will resume from the **latest checkpoint** from the current `[YourExptName]` by default. For example, if you want to resume training from the latest checkpoint in `Amphion/ckpts/tts/[YourExptName]/checkpoint`, run:
+
+```bash
+sh egs/tts/VITS/run.sh --stage 2 --name [YourExptName] \
+    --resume true
+```
+
+You can also choose a **specific checkpoint** for retraining by `--resume_from_ckpt_path` argument. For example, if you want to resume training from the checkpoint `Amphion/ckpts/tts/[YourExptName]/checkpoint/[SpecificCheckpoint]`, run:
+
+```bash
+sh egs/tts/VITS/run.sh --stage 2 --name [YourExptName] \
+    --resume true
+    --resume_from_ckpt_path "Amphion/ckpts/tts/[YourExptName]/checkpoint/[SpecificCheckpoint]" \
+```
+
+If you want to **fine-tune from another checkpoint**, just use `--resume_type` and set it to `"finetune"`. For example, If you want to fine-tune the model from the checkpoint `Amphion/ckpts/tts/[AnotherExperiment]/checkpoint/[SpecificCheckpoint]`, run:
+
+
+```bash
+sh egs/tts/VITS/run.sh --stage 2 --name [YourExptName] \
+    --resume true
+    --resume_from_ckpt_path "Amphion/ckpts/tts/[YourExptName]/checkpoint/[SpecificCheckpoint]" \
+    --resume_type "finetune"
+```
+
+> **NOTE:** The `--resume_type` is set as `"resume"` in default. It's not necessary to specify it when resuming training.
+> 
+> The difference between `"resume"` and `"finetune"` is that the `"finetune"` will **only** load the pretrained model weights from the checkpoint, while the `"resume"` will load all the training states (including optimizer, scheduler, etc.) from the checkpoint.
+
+Here are some example scenarios to better understand how to use these arguments:
+| Scenario | `--resume` | `--resume_from_ckpt_path` | `--resume_type` |
+| ------ | -------- | ----------------------- | ------------- |
+| You want to train from scratch | no | no | no |
+| The machine breaks down during training and you want to resume training from the latest checkpoint | `true` | no | no |
+| You find the latest model is overfitting and you want to re-train from the checkpoint before | `true` | `SpecificCheckpoint Path` | no |
+| You want to fine-tune a model from another checkpoint | `true` | `SpecificCheckpoint Path` | `"finetune"` |
+
 
 > **NOTE:** The `CUDA_VISIBLE_DEVICES` is set as `"0"` in default. You can change it when running `run.sh` by specifying such as `--gpu "0,1,2,3"`.
 

--- a/models/tts/base/tts_trainer.py
+++ b/models/tts/base/tts_trainer.py
@@ -304,18 +304,18 @@ class TTSTrainer(BaseTrainer):
                         ckpt_name = "pytorch_model.bin"
                     else:
                         ckpt_name = "pytorch_model_{}.bin".format(idx)
-                        
+
                     self.model[sub_model].load_state_dict(
                         torch.load(os.path.join(checkpoint_path, ckpt_name))
-                    )   
-                self.model[sub_model].cuda(self.accelerator.device)  
-            else:      
+                    )
+                self.model[sub_model].cuda(self.accelerator.device)
+            else:
                 self.model.load_state_dict(
                     torch.load(os.path.join(checkpoint_path, "pytorch_model.bin"))
                 )
                 self.model.cuda(self.accelerator.device)
-            self.logger.info("Load model weights for finetune SUCCESS!")           
-                
+            self.logger.info("Load model weights for finetune SUCCESS!")
+
         else:
             raise ValueError("Unsupported resume type: {}".format(resume_type))
 

--- a/models/tts/base/tts_trainer.py
+++ b/models/tts/base/tts_trainer.py
@@ -179,11 +179,6 @@ class TTSTrainer(BaseTrainer):
                 open(os.path.join(self.ckpt_path, "ckpts.json"), "r")
             )
 
-        self.checkpoint_dir = os.path.join(self.exp_dir, "checkpoint")
-        if self.accelerator.is_main_process:
-            os.makedirs(self.checkpoint_dir, exist_ok=True)
-        self.logger.debug(f"Checkpoint directory: {self.checkpoint_dir}")
-
     def _init_accelerator(self):
         self.exp_dir = os.path.join(
             os.path.abspath(self.cfg.log_dir), self.args.exp_name
@@ -292,7 +287,7 @@ class TTSTrainer(BaseTrainer):
         it will load the checkpoint specified by checkpoint_path.
         **Only use this method after** ``accelerator.prepare()``.
         """
-        if checkpoint_path is None:
+        if checkpoint_path is None or checkpoint_path == "":
             ls = [str(i) for i in Path(checkpoint_dir).glob("*")]
             ls.sort(key=lambda x: int(x.split("_")[-3].split("-")[-1]), reverse=True)
             checkpoint_path = ls[0]
@@ -303,11 +298,24 @@ class TTSTrainer(BaseTrainer):
             self.epoch = int(checkpoint_path.split("_")[-3].split("-")[-1]) + 1
             self.step = int(checkpoint_path.split("_")[-2].split("-")[-1]) + 1
         elif resume_type == "finetune":
-            self.model.load_state_dict(
-                torch.load(os.path.join(checkpoint_path, "pytorch_model.bin"))
-            )
-            self.model.cuda(self.accelerator.device)
-            self.logger.info("Load model weights for finetune SUCCESS!")
+            if isinstance(self.model, dict):
+                for idx, sub_model in enumerate(self.model.keys()):
+                    if idx == 0:
+                        ckpt_name = "pytorch_model.bin"
+                    else:
+                        ckpt_name = "pytorch_model_{}.bin".format(idx)
+                        
+                    self.model[sub_model].load_state_dict(
+                        torch.load(os.path.join(checkpoint_path, ckpt_name))
+                    )   
+                self.model[sub_model].cuda(self.accelerator.device)  
+            else:      
+                self.model.load_state_dict(
+                    torch.load(os.path.join(checkpoint_path, "pytorch_model.bin"))
+                )
+                self.model.cuda(self.accelerator.device)
+            self.logger.info("Load model weights for finetune SUCCESS!")           
+                
         else:
             raise ValueError("Unsupported resume type: {}".format(resume_type))
 


### PR DESCRIPTION
## ✨ Description

* Fix the bug for VITS resuming training
* Add support for VITS resuming training and fine-tuning.
* Have tested on VITS, including training from scratch, resuming training and fine-tuning, and VALL-E, including stage 1 training and stage 2 training.

## 🚧 Related Issues

Issue #94 

## 👨‍💻 Changes Proposed

- [x] Add a user-friendly interface in `egs/tts/VITS/run.sh` to use the arguments related to resuming or fine-tuning VITS model.
- [x] Add support in `models/tts/base/tts_trainer.py` for fine-tuning VITS model.
- [x] Add usage instructions in `egs/tts/VITS/README.md` about training VITS from scratch, resuming, or finetuning.

## 🧑‍🤝‍🧑 Who Can Review?
@viewfinder-annn @RMSnow @VocodexElysium 


## 🛠 TODO

No TODO.

## ✅ Checklist

- [x]  Code has been reviewed
- [x]  Code complies with the project's code standards and best practices
- [x]  Code has passed all tests
- [x]  Code does not affect the normal use of existing features
- [x]  Code has been commented properly
- [x]  Documentation has been updated (if applicable)
- [x]  Demo/checkpoint has been attached (if applicable)
