### PR TITLE
MFA Restructure & Environment Bug Fixes

### DIFF
--- a/egs/tts/FastSpeech2/prepare_mfa.sh
+++ b/egs/tts/FastSpeech2/prepare_mfa.sh
@@ -4,11 +4,26 @@
 # LICENSE file in the root directory of this source tree.
 
 #!/bin/bash
-mkdir mfa
-cd mfa
-wget https://github.com/MontrealCorpusTools/Montreal-Forced-Aligner/releases/download/v1.1.0-beta.2/montreal-forced-aligner_linux.tar.gz
-tar -zxvf montreal-forced-aligner_linux.tar.gz
-cd mfa
-mkdir lexicon
-cd lexicon
-wget http://www.openslr.org/resources/11/librispeech-lexicon.txt
+
+# Navigate to the 'pretrained' directory
+cd pretrained || { echo "Failed to change directory to 'pretrained'"; exit 1; }
+
+# Create and navigate to the 'mfa' directory
+mkdir -p mfa && cd mfa || { echo "Failed to create or change directory to 'mfa'"; exit 1; }
+
+# Define the MFA file URL and the file name
+mfa_url="https://github.com/MontrealCorpusTools/Montreal-Forced-Aligner/releases/download/v1.1.0-beta.2/montreal-forced-aligner_linux.tar.gz"
+mfa_file="montreal-forced-aligner_linux.tar.gz"
+
+# Download MFA if it doesn't exist
+if [ ! -f "$mfa_file" ]; then
+    wget "$mfa_url" || { echo "Failed to download MFA"; exit 1; }
+fi
+
+# Extract MFA
+tar -zxvf "$mfa_file" || { echo "Failed to extract MFA"; exit 1; }
+
+# Optionally, remove the tar.gz file after extraction
+rm "$mfa_file"
+
+echo "MFA setup completed successfully."

--- a/egs/tts/FastSpeech2/run.sh
+++ b/egs/tts/FastSpeech2/run.sh
@@ -16,7 +16,7 @@ mkdir -p monotonic_align
 python setup.py build_ext --inplace
 cd $work_dir
 
-mfa_dir=$work_dir/mfa
+mfa_dir=$work_dir/pretrained/mfa
 echo $mfa_dir
 
 ######## Parse the Given Parameters from the Commond ###########
@@ -71,7 +71,7 @@ fi
 
 ######## Features Extraction ###########
 if [ $running_stage -eq 1 ]; then
-    if [ ! -d "$mfa_dir" ]; then
+    if [ ! -d "$mfa_dir/montreal-forced-aligner" ]; then
         bash ${exp_dir}/prepare_mfa.sh
     fi
     CUDA_VISIBLE_DEVICES=$gpu python "${work_dir}"/bins/tts/preprocess.py \

--- a/env.sh
+++ b/env.sh
@@ -9,7 +9,7 @@ conda install -c conda-forge ffmpeg
 # Pip packages
 pip install setuptools ruamel.yaml tqdm colorama easydict tabulate loguru json5 Cython unidecode inflect argparse g2p_en tgt librosa==0.9.1 matplotlib typeguard einops omegaconf hydra-core humanfriendly pandas
 
-pip install tensorboard tensorboardX torch==2.0.1 torchaudio==2.0.2 torchvision==0.15.2 accelerate==0.24.1 transformers diffusers praat-parselmouth audiomentations pedalboard ffmpeg-python==0.2.0 pyworld diffsptk nnAudio unidecode inflect ptwt
+pip install tensorboard tensorboardX torch==2.0.1 torchaudio==2.0.2 torchvision==0.15.2 accelerate==0.24.1 transformers diffusers praat-parselmouth audiomentations pedalboard ffmpeg-python==0.2.0 pyworld diffsptk==1.0.1 nnAudio unidecode inflect ptwt
 
 pip install torchmetrics pymcd openai-whisper frechet_audio_distance asteroid resemblyzer vector-quantize-pytorch==1.12.5
 

--- a/env.sh
+++ b/env.sh
@@ -7,7 +7,7 @@
 conda install -c conda-forge ffmpeg
 
 # Pip packages
-pip install setuptools ruamel.yaml tqdm colorama easydict tabulate loguru json5 Cython unidecode inflect argparse g2p_en tgt librosa matplotlib typeguard einops omegaconf hydra-core humanfriendly pandas
+pip install setuptools ruamel.yaml tqdm colorama easydict tabulate loguru json5 Cython unidecode inflect argparse g2p_en tgt librosa==0.9.1 matplotlib typeguard einops omegaconf hydra-core humanfriendly pandas
 
 pip install tensorboard tensorboardX torch==2.0.1 torchaudio==2.0.2 torchvision==0.15.2 accelerate==0.24.1 transformers diffusers praat-parselmouth audiomentations pedalboard ffmpeg-python==0.2.0 pyworld diffsptk nnAudio unidecode inflect ptwt
 

--- a/env.sh
+++ b/env.sh
@@ -11,7 +11,7 @@ pip install setuptools ruamel.yaml tqdm colorama easydict tabulate loguru json5 
 
 pip install tensorboard tensorboardX torch==2.0.1 torchaudio==2.0.2 torchvision==0.15.2 accelerate==0.24.1 transformers diffusers praat-parselmouth audiomentations pedalboard ffmpeg-python==0.2.0 pyworld diffsptk nnAudio unidecode inflect ptwt
 
-pip install torchmetrics pymcd openai-whisper frechet_audio_distance asteroid resemblyzer
+pip install torchmetrics pymcd openai-whisper frechet_audio_distance asteroid resemblyzer vector-quantize-pytorch==1.12.5
 
 pip install https://github.com/vBaiCai/python-pesq/archive/master.zip
 

--- a/preprocessors/ljspeech.py
+++ b/preprocessors/ljspeech.py
@@ -24,10 +24,16 @@ import numpy as np
 def textgird_extract(
     corpus_directory,
     output_directory,
-    mfa_path=os.path.join("mfa", "montreal-forced-aligner", "bin", "mfa_align"),
-    lexicon=os.path.join("mfa", "lexicon", "librispeech-lexicon.txt"),
+    mfa_path=os.path.join(
+        "pretrained", "mfa", "montreal-forced-aligner", "bin", "mfa_align"
+    ),
+    lexicon=os.path.join("text", "lexicon", "librispeech-lexicon.txt"),
     acoustic_model_path=os.path.join(
-        "mfa", "montreal-forced-aligner", "pretrained_models", "english.zip"
+        "pretrained",
+        "mfa",
+        "montreal-forced-aligner",
+        "pretrained_models",
+        "english.zip",
     ),
     jobs="8",
 ):


### PR DESCRIPTION
## ✨ Description

- Address fs2 preprocessing exception due to mismatched package versions
- Refactor MFA file structure into `/pretrained` and modify control logic in fetching and managing MFA files

## 🚧 Related Issues

- Issue #118, error in training from LJSpeech dataset, arising from outdated file paths for lexicon dictionary.
- Issue #119, due to package manager installing librosa 0.10+, which deprecated audioread support (See [librosa 0.10 documentation](https://librosa.org/doc/0.10.1/generated/librosa.load.html#librosa.load))

- Further testing identified additional environment issues arising from newer dependency versions causing errors. After isolation testing, `diffsptk` is confirmed to cause the error. More specifically, the dependency `vector-quantize-pytorch`. The package manager fetches `vector_quantize_pytorch` 1.12.16 by default (notice the underscores instead of hyphens in the package name) instead of `vector-quantize-pytorch`. Therefore, the version should also be specified for this package to be no more than 1.12.5 for now until a change in package manager behavior.

## 👨‍💻 Changes Proposed

- [x] Modifying directories in `preprocessors/ljspeech.py` to change the saving directory for MFA files from the root folder to `/pretrained` to comply with file management convention for Amphion system; additionally, link lexicon directory to provided lexicon file to avoid redundant files.
- [x] Rewrite `prepare_mfa.sh` and modify `run.sh` for a more robust logic in fetching and managing MFA files; removing the redundant section for downloading LJSpeech lexicon.
- [x] Modifying env.sh to specify `librosa` version to 0.9.1 and `vector-quantize-pytorch` to 1.12.5

## 🧑‍🤝‍🧑 Who Can Review?

@lmxue @RMSnow 

## 🛠 TODO

*Potential Consideration*: A few issues seem to arise from preparing environments, one consideration could be to freeze versions for certain packages for better stability @RMSnow.

## ✅ Checklist

- [x]  Code has been reviewed
- [x]  Code complies with the project's code standards and best practices
- [x]  Code has passed all tests
- [x]  Code does not affect the normal use of existing features
- [x]  Code has been commented properly
- [x]  Documentation has been updated (if applicable)
- [x]  Demo/checkpoint has been attached (if applicable)
