### PR TITLE
fix: G2P module fails to initialize #138

### DIFF
--- a/text/g2p_module.py
+++ b/text/g2p_module.py
@@ -113,6 +113,7 @@ class G2PModule:
         language_switch: LanguageSwitch = "keep-flags",
         words_mismatch: WordMismatch = "ignore",
     ) -> None:
+        self.separator = separator
         self.backend = self._initialize_backend(
             backend,
             language,
@@ -123,7 +124,6 @@ class G2PModule:
             language_switch,
             words_mismatch,
         )
-        self.separator = separator
 
     def _initialize_backend(
         self,


### PR DESCRIPTION
## ✨ Description

The G2P module fails to initialize due to using an unassigned variable. This PR fixes this bug.

## 🚧 Related Issues

#138 

## 👨‍💻 Changes Proposed

- [x] Fix the bug

## 🧑‍🤝‍🧑 Who Can Review?

@lmxue

## 🛠 TODO

None

## ✅ Checklist

- [ ]  Code has been reviewed
- [x]  Code complies with the project's code standards and best practices
- [x]  Code has passed all tests
- [x]  Code does not affect the normal use of existing features
- [x]  Code has been commented properly
- [x]  Documentation has been updated (if applicable)
- [x]  Demo/checkpoint has been attached (if applicable)
