### PR TITLE
Added data padding to 'forward', 'inference', and 'get_prosody_featur…

### DIFF
--- a/models/codec/ns3_codec/facodec.py
+++ b/models/codec/ns3_codec/facodec.py
@@ -811,15 +811,28 @@ class FACodecEncoderV2(nn.Module):
 
         self.reset_parameters()
 
+    def _pad_data(self, x):
+        """Pads the input audio data 'x'."""
+
+        remainder = x.size(-1) % self.hop_length
+        if remainder != 0:
+            pad_size = self.hop_length - remainder
+        else:
+            pad_size = 0
+        x_padded = F.pad(x, (0, pad_size))
+        return x_padded
+    
     def forward(self, x):
-        out = self.block(x)
-        return out
+        x_padded = self._pad_data(x)
+        return self.block(x_padded)
 
     def inference(self, x):
-        return self.block(x)
+        x_padded = self._pad_data(x)
+        return self.block(x_padded)
 
     def get_prosody_feature(self, x):
-        return self.mel_transform(x.squeeze(1))[:, :20, :]
+        x_padded = self._pad_data(x)
+        return self.mel_transform(x_padded.squeeze(1))[:, :20, :]
 
     def remove_weight_norm(self):
         """Remove weight normalization module from all of the layers."""


### PR DESCRIPTION
Fix Issue #188

## ✨ Description

This PR adds data padding functionality to the `forward`, `inference`, and `get_prosody_feature` methods in our model class. The `_pad_data` function pads the input audio tensor, making sure that its last dimension is a multiple of the hop length. This is common in audio processing where all frames need to have equal lengths for certain computations or analyses.

To test this PR, run any processes that use the `forward`, `inference`, and `get_prosody_feature` methods and observe if there are any issues or improvements with how the processed audio data aligns with the hop length.


## 🚧 Related Issues

- Issue #188 [BUG]: the lengths of the features after FACodecEncoderV2 is not match

## 👨‍💻 Changes Proposed

- [x] Added `_pad_data` method which pads an input tensor along its last dimension.
- [x] Modified `forward`, `inference`, and `get_prosody_feature` methods to use `_pad_data`.

## 🧑‍🤝‍🧑 Who Can Review?

## 🛠 TODO

## ✅ Checklist

- [ ]  Code has been reviewed
- [ ]  Code complies with the project's code standards and best practices
- [ ]  Code has passed all tests
- [ ]  Code does not affect the normal use of existing features
- [ ]  Code has been commented properly
- [ ]  Documentation has been updated (if applicable)
- [ ]  Demo/checkpoint has been attached (if applicable)
