### PR TITLE
FastSpeech2 using wrong control for energy

### DIFF
--- a/models/tts/fastspeech2/fs2.py
+++ b/models/tts/fastspeech2/fs2.py
@@ -215,7 +215,7 @@ class VarianceAdaptor(nn.Module):
             x = x + pitch_embedding
         if self.energy_feature_level == "frame_level":
             energy_prediction, energy_embedding = self.get_energy_embedding(
-                x, energy_target, mel_mask, p_control
+                x, energy_target, mel_mask, e_control
             )
             x = x + energy_embedding
 


### PR DESCRIPTION
## ✨ Description

> [!CAUTION]
> The input variable `p_control` is wrong for `self.get_energy_embedding`, it should be `e_control` as used in the former code.

## 🚧 Related Issues

## 👨‍💻 Changes Proposed

- [ ] change `p_control` to `e_control`.

## 🧑‍🤝‍🧑 Who Can Review?

## 🛠 TODO

## ✅ Checklist

- [ ]  Code has been reviewed
- [ ]  Code complies with the project's code standards and best practices
- [ ]  Code has passed all tests
- [ ]  Code does not affect the normal use of existing features
- [ ]  Code has been commented properly
- [ ]  Documentation has been updated (if applicable)
- [ ]  Demo/checkpoint has been attached (if applicable)
