### PR TITLE
Fix Semantic Feature Extraction from Incorrect Layer

### DIFF
--- a/models/tts/maskgct/maskgct_utils.py
+++ b/models/tts/maskgct/maskgct_utils.py
@@ -114,7 +114,7 @@ class MaskGCT_Inference_Pipeline:
             attention_mask=attention_mask,
             output_hidden_states=True,
         )
-        feat = vq_emb.hidden_states[17]  # (B, T, C)
+        feat = vq_emb.hidden_states[16]  # (B, T, C)
         feat = (feat - self.semantic_mean.to(feat)) / self.semantic_std.to(feat)
 
         semantic_code, rec_feat = self.semantic_codec.quantize(feat)  # (B, T)


### PR DESCRIPTION
This PR addresses an inconsistency between the code and the paper regarding which layer is used for semantic feature extraction in W2v-BERT 2.0. The [paper](https://arxiv.org/abs/2409.00750) specifies:

> "In detail, we utilize the hidden states from the 17th layer of W2v-BERT 2.0."

However, in the current [code](https://github.com/open-mmlab/Amphion/blob/main/models/tts/maskgct/maskgct_utils.py#L117), the features are extracted using `feat = vq_emb.hidden_states[17]`, which actually points to the 18th layer due to zero-based indexing in Python. This PR updates the code to use `vq_emb.hidden_states[16]`, aligning it with the paper's description if it indeed intended to refer to the 17th layer.

**Question:** Could you clarify if this is an error in the paper or the code? This PR assumes the paper’s statement is correct, but confirmation would be helpful.