### PR TITLE
Fix langid to py3langid

### DIFF
--- a/models/tts/metis/metis.py
+++ b/models/tts/metis/metis.py
@@ -18,7 +18,7 @@ from peft import LoraModel, LoraConfig
 
 from huggingface_hub import hf_hub_download, snapshot_download
 
-import langid
+import py3langid as langid
 
 
 def build_metis_stage1(cfg, device, ft_type=None):


### PR DESCRIPTION
## ✨ Description

When using metis, an error occurs saying that langid cannot be imported.
I fix `langid` to `py3langid as langid`.

## 🚧 Related Issues

[List the issue numbers related to this PR]

## 👨‍💻 Changes Proposed

- [ ] change1
- [ ] ...

## 🧑‍🤝‍🧑 Who Can Review?

[Please use the '@' symbol to mention any community member who is free to review the PR once the tests have passed. Feel free to tag members or contributors who might be interested in your PR.]

## 🛠 TODO

- [ ] task1
- [ ] ...

## ✅ Checklist

- [ ]  Code has been reviewed
- [ ]  Code complies with the project's code standards and best practices
- [ ]  Code has passed all tests
- [ ]  Code does not affect the normal use of existing features
- [ ]  Code has been commented properly
- [ ]  Documentation has been updated (if applicable)
- [ ]  Demo/checkpoint has been attached (if applicable)
