### PR TITLE
Ensure UTF-8 encoding for file reads to support Windows MaskGCT inference

### DIFF
--- a/models/tts/maskgct/g2p/g2p/__init__.py
+++ b/models/tts/maskgct/g2p/g2p/__init__.py
@@ -25,7 +25,7 @@ class PhonemeBpeTokenizer:
         self.text_tokenizers = {}
         self.int_text_tokenizers()
 
-        with open(vacab_path, "r") as f:
+        with open(vacab_path, "r", encoding="utf-8") as f:
             json_data = f.read()
         data = json.loads(json_data)
         self.vocab = data["vocab"]

--- a/models/tts/maskgct/g2p/g2p_generation.py
+++ b/models/tts/maskgct/g2p/g2p_generation.py
@@ -114,7 +114,7 @@ def chn_eng_g2p(text: str):
 
 
 text_tokenizer = PhonemeBpeTokenizer()
-with open("./models/tts/maskgct/g2p/g2p/vocab.json", "r") as f:
+with open("./models/tts/maskgct/g2p/g2p/vocab.json", "r", encoding="utf-8") as f:
     json_data = f.read()
 data = json.loads(json_data)
 vocab = data["vocab"]

--- a/models/tts/maskgct/g2p/utils/g2p.py
+++ b/models/tts/maskgct/g2p/utils/g2p.py
@@ -60,7 +60,7 @@ lang2backend = {
     "de": phonemizer_de,
 }
 
-with open("./models/tts/maskgct/g2p/utils/mls_en.json", "r") as f:
+with open("./models/tts/maskgct/g2p/utils/mls_en.json", "r", encoding="utf-8") as f:
     json_data = f.read()
 token = json.loads(json_data)
 


### PR DESCRIPTION
## ✨ Description

Before this fix, MaskGCT TTS produced unintelligible sounds instead of meaningful speech during inference on Windows. The issue was caused by reading JSON files without explicitly specifying UTF-8 encoding.

On systems where Python's default encoding is not set to UTF-8, this led to incorrect parsing of vocabulary/phoneme data, tampering the speech synthesis process.

[before_and_after.zip](https://github.com/user-attachments/files/19112113/before_and_after.zip)

## 🚧 Related Issues

#327 

https://github.com/justinjohn0306/MaskGCT-Windows
