### PR TITLE
Fixed MaskGCT demo crash if using cpu

### DIFF
--- a/models/tts/maskgct/gradio_demo.py
+++ b/models/tts/maskgct/gradio_demo.py
@@ -28,7 +28,7 @@ import whisper
 
 print("Start loading: facebook/w2v-bert-2.0")
 processor = SeamlessM4TFeatureExtractor.from_pretrained("facebook/w2v-bert-2.0")
-device = torch.device("cuda" if torch.cuda.is_available() else "CPU")
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 whisper_model = None
 output_file_name_idx = 0
 


### PR DESCRIPTION
This fixes a crash in the MaskGCT demo if the user is using a CPU instead of CUDA.