### PR TITLE
Security: Unsafe deserialization via torch.load in checkpoint loader

### DIFF
--- a/models/tta/ldm/inference_utils/utils.py
+++ b/models/tta/ldm/inference_utils/utils.py
@@ -43,7 +43,10 @@ def get_padding(kernel_size, dilation=1):
 def load_checkpoint(filepath, device):
     assert os.path.isfile(filepath)
     print("Loading '{}'".format(filepath))
-    checkpoint_dict = torch.load(filepath, map_location=device)
+    try:
+        checkpoint_dict = torch.load(filepath, map_location=device, weights_only=True)
+    except TypeError:
+        checkpoint_dict = torch.load(filepath, map_location=device)
     print("Complete.")
     return checkpoint_dict
 

--- a/models/tta/picoaudio/picoaudio/audioldm/hifigan/utilities.py
+++ b/models/tta/picoaudio/picoaudio/audioldm/hifigan/utilities.py
@@ -41,7 +41,10 @@ HIFIGAN_16K_64 = {
 
 def get_available_checkpoint_keys(model, ckpt):
     print("==> Attemp to reload from %s" % ckpt)
-    state_dict = torch.load(ckpt)["state_dict"]
+    try:
+        state_dict = torch.load(ckpt, weights_only=True)["state_dict"]
+    except TypeError:
+        state_dict = torch.load(ckpt)["state_dict"]
     current_state_dict = model.state_dict()
     new_state_dict = {}
     for k in state_dict.keys():


### PR DESCRIPTION
## Problem

The checkpoint loader directly calls `torch.load(filepath, map_location=device)` on a path without trust validation. `torch.load` uses pickle under the hood and can execute arbitrary code when loading a malicious checkpoint.

**Severity**: `high`
**File**: `models/tta/ldm/inference_utils/utils.py`

## Solution

Treat checkpoints as untrusted input. Prefer `safetensors` for model weights, or enforce strict trust boundaries and signature/hash verification before loading. If using PyTorch >=2.0, consider safer loading patterns and avoid arbitrary pickled objects.

## Changes

- `models/tta/ldm/inference_utils/utils.py` (modified)
- `models/tta/picoaudio/picoaudio/audioldm/hifigan/utilities.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
