### PR TITLE
Switch diarization model in Emilia to pyannote community-1

### DIFF
--- a/preprocessors/Emilia/README.md
+++ b/preprocessors/Emilia/README.md
@@ -75,7 +75,7 @@ The Emilia-Pipe includes the following major steps:
 
 3. Download the model files from the third-party repositories.
     - Manually download the checkpoints of UVR-MDX-NET-Inst_HQ_3 ([UVR-MDX-NET-Inst_3.onnx](https://github.com/TRvlvr/model_repo/releases/download/all_public_uvr_models/UVR-MDX-NET-Inst_HQ_3.onnx)) and DNSMOS P.835 ([sig_bak_ovr.onnx](https://github.com/microsoft/DNS-Challenge/blob/master/DNSMOS/DNSMOS/sig_bak_ovr.onnx)), then save their path for the next step configuration (i.e. #2  and #3 TODO).
-    - Creat the access token to pyannote/speaker-diarization-community-1 following [the guide](https://huggingface.co/pyannote/speaker-diarization-community-1), then save it for the next step configuration (i.e. #4 TODO).
+    - Create the access token to pyannote/speaker-diarization-community-1 following [the guide](https://huggingface.co/pyannote/speaker-diarization-community-1), then save it for the next step configuration (i.e. #4 TODO).
     - Make sure you have stable connection to GitHub and HuggingFace. The checkpoints of Silero and Whisperx-medium will be downloaded automatically on the pipeline's first run. 
 
 

--- a/preprocessors/Emilia/README.md
+++ b/preprocessors/Emilia/README.md
@@ -75,7 +75,7 @@ The Emilia-Pipe includes the following major steps:
 
 3. Download the model files from the third-party repositories.
     - Manually download the checkpoints of UVR-MDX-NET-Inst_HQ_3 ([UVR-MDX-NET-Inst_3.onnx](https://github.com/TRvlvr/model_repo/releases/download/all_public_uvr_models/UVR-MDX-NET-Inst_HQ_3.onnx)) and DNSMOS P.835 ([sig_bak_ovr.onnx](https://github.com/microsoft/DNS-Challenge/blob/master/DNSMOS/DNSMOS/sig_bak_ovr.onnx)), then save their path for the next step configuration (i.e. #2  and #3 TODO).
-    - Creat the access token to pyannote/speaker-diarization-3.1 following [the guide](https://huggingface.co/pyannote/speaker-diarization-3.1#requirements), then save it for the next step configuration (i.e. #4 TODO).
+    - Creat the access token to pyannote/speaker-diarization-community-1 following [the guide](https://huggingface.co/pyannote/speaker-diarization-community-1), then save it for the next step configuration (i.e. #4 TODO).
     - Make sure you have stable connection to GitHub and HuggingFace. The checkpoints of Silero and Whisperx-medium will be downloaded automatically on the pipeline's first run. 
 
 
@@ -175,7 +175,7 @@ Here are some potential improvements for the Emilia-Pipe pipeline:
 We acknowledge the wonderful work by these excellent developers!
 - Source Separation: [UVR-MDX-NET-Inst_HQ_3](https://github.com/TRvlvr/model_repo/releases/tag/all_public_uvr_models)
 - VAD: [snakers4/silero-vad](https://github.com/snakers4/silero-vad)
-- Speaker Diarization: [pyannote/speaker-diarization-3.1](https://huggingface.co/pyannote/speaker-diarization-3.1)
+- Speaker Diarization: [pyannote/speaker-diarization-community-1](https://huggingface.co/pyannote/speaker-diarization-community-1)
 - ASR: [m-bain/whisperX](https://github.com/m-bain/whisperX), using [faster-whisper](https://github.com/guillaumekln/faster-whisper) and [CTranslate2](https://github.com/OpenNMT/CTranslate2) backend.
 - DNSMOS Prediction: [DNSMOS P.835](https://github.com/microsoft/DNS-Challenge)
 

--- a/preprocessors/Emilia/README.md
+++ b/preprocessors/Emilia/README.md
@@ -67,7 +67,7 @@ The Emilia-Pipe includes the following major steps:
 2. Run the following commands to install the required packages:
 
     ```bash
-    conda create -y -n AudioPipeline python=3.9 
+    conda create -y -n AudioPipeline python=3.10
     conda activate AudioPipeline
 
     bash env.sh

--- a/preprocessors/Emilia/main.py
+++ b/preprocessors/Emilia/main.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
+import inspect
 import json
 import librosa
 import numpy as np
@@ -151,6 +152,10 @@ def speaker_diarization(audio):
             "channel": 0,
         }
     )
+    # pyannote.audio 4.x returns a rich output object with speaker_diarization.
+    # Legacy versions return Annotation directly.
+    if hasattr(segments, "speaker_diarization"):
+        segments = segments.speaker_diarization
 
     diarize_df = pd.DataFrame(
         segments.itertracks(yield_label=True),
@@ -523,9 +528,13 @@ if __name__ == "__main__":
             "You can get the token at https://huggingface.co/settings/tokens. "
             "Remeber grant access following https://github.com/pyannote/pyannote-audio?tab=readme-ov-file#tldr"
         )
+    from_pretrained_params = inspect.signature(Pipeline.from_pretrained).parameters
+    auth_kwarg = (
+        "token" if "token" in from_pretrained_params else "use_auth_token"
+    )
     dia_pipeline = Pipeline.from_pretrained(
         "pyannote/speaker-diarization-community-1",
-        use_auth_token=cfg["huggingface_token"],
+        **{auth_kwarg: cfg["huggingface_token"]},
     )
     dia_pipeline.to(device)
 

--- a/preprocessors/Emilia/main.py
+++ b/preprocessors/Emilia/main.py
@@ -524,7 +524,7 @@ if __name__ == "__main__":
             "Remeber grant access following https://github.com/pyannote/pyannote-audio?tab=readme-ov-file#tldr"
         )
     dia_pipeline = Pipeline.from_pretrained(
-        "pyannote/speaker-diarization-3.1",
+        "pyannote/speaker-diarization-community-1",
         use_auth_token=cfg["huggingface_token"],
     )
     dia_pipeline.to(device)

--- a/preprocessors/Emilia/main.py
+++ b/preprocessors/Emilia/main.py
@@ -529,9 +529,7 @@ if __name__ == "__main__":
             "Remeber grant access following https://github.com/pyannote/pyannote-audio?tab=readme-ov-file#tldr"
         )
     from_pretrained_params = inspect.signature(Pipeline.from_pretrained).parameters
-    auth_kwarg = (
-        "token" if "token" in from_pretrained_params else "use_auth_token"
-    )
+    auth_kwarg = "token" if "token" in from_pretrained_params else "use_auth_token"
     dia_pipeline = Pipeline.from_pretrained(
         "pyannote/speaker-diarization-community-1",
         **{auth_kwarg: cfg["huggingface_token"]},


### PR DESCRIPTION
## ✨ Description

This PR updates Emilia diarization to use `pyannote/speaker-diarization-community-1` and adds compatibility handling so the pipeline works across pyannote API variants.

Changes:
- `preprocessors/Emilia/main.py`
  - Switch diarization model from `pyannote/speaker-diarization-3.1` to `pyannote/speaker-diarization-community-1`.
  - Support both auth argument styles:
    - `token=...` (pyannote 4.x)
    - `use_auth_token=...` fallback (older versions)
  - Normalize diarization output handling:
    - use `out.speaker_diarization` when present
    - fallback to legacy `Annotation` output
- `preprocessors/Emilia/README.md`
  - Update model references from `3.1` to `community-1`.
  - Update environment example from Python `3.9` to `3.10`.

Rationale:
- pyannote reports `community-1` as improved over legacy `3.1` on most published benchmarks (with dataset-specific variance).

## 🚧 Related Issues

Closes #486

## 👨‍💻 Changes Proposed

- [x] Migrate Emilia diarization model ID to `community-1`
- [x] Add cross-version pyannote auth/output compatibility handling
- [x] Update README setup/model references

## 🧑‍🤝‍🧑 Who Can Review?

@yuantuo666
@HarryHe11 

## ✅ Checklist

- [ ]  Code has been reviewed
- [x]  Code complies with the project's code standards and best practices
- [x]  Code has passed all tests
- [x]  Code does not affect the normal use of existing features
- [x]  Code has been commented properly
- [x]  Documentation has been updated (if applicable)
- [ ]  Demo/checkpoint has been attached (if applicable)

## Test Notes

Manual smoke test executed with a real audio sample and HF token:
- pipeline loads `community-1`
- diarization runs successfully
- output conversion path works (`speaker_diarization`/legacy fallback)
- first segment produced correctly